### PR TITLE
Add a landing page check

### DIFF
--- a/src/client/config.html
+++ b/src/client/config.html
@@ -44,7 +44,7 @@
           if (key === 'landingPageUrl') {
             if (checkLandingPageUrl(value)) {
               alert(
-                'The landing page is set to localhost but the emulator appears to be running on a remote host. Please confirm the landing page URL is correct. '
+                'The landing page is set to localhost but the emulator appears to be running on a remote host. Please confirm the landing page URL is correct.'
               );
             }
           }

--- a/src/client/config.html
+++ b/src/client/config.html
@@ -41,6 +41,14 @@
         if (!value) {
           alert('Enter a value.');
         } else {
+          if (key === 'landingPageUrl') {
+            if (checkLandingPageUrl(value)) {
+              alert(
+                'The landing page is set to localhost but the emulator appears to be running on a remote host. Please confirm the landing page URL is correct. '
+              );
+            }
+          }
+
           if (confirm('Are you really sure?')) {
             const $this = $(e.target);
             const value = $this.parent().children('input').val();
@@ -67,6 +75,11 @@
             window.location.reload(true);
           }
         }
+      }
+
+      // Check if we're running on a remote host but the landing page has been left as default (localhost)
+      function checkLandingPageUrl(landingPageUrl) {
+        return landingPageUrl.startsWith('http://localhost') && $(location).attr('hostname') !== 'localhost';
       }
     </script>
   </head>
@@ -118,6 +131,11 @@
               This form allows you to update environment variables for the emulator.
               <span class="font-bold">Understand the scope </span>of the variables before updating to avoid unexpexted
               behaviours from the emulator that may distort testing retults.
+            </p>
+            <p class="py-2">
+              Note: The default value for "Landing Page URL" assumes you are running the emulator locally. If you are
+              running the emulator on a remote host (eg in Azure Container Images) update the Landing Page URL with the
+              IP address or FQDN of your remote host.
             </p>
           </div>
         </div>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -149,6 +149,11 @@
         $temp.remove();
       }
 
+      // Check if we're running on a remote host but the landing page has been left as default (localhost)
+      function checkLandingPageUrl(landingPageUrl) {
+        return landingPageUrl.startsWith('http://localhost') && $(location).attr('hostname') !== 'localhost';
+      }
+
       // post the token to the given landing page URL
       async function posttoLanding(element) {
         const response = await fetch('/api/util/config', { method: 'GET' });
@@ -162,6 +167,12 @@
 
         if (!landingPage) {
           alert('No landing page URL set in config.');
+        }
+
+        if (checkLandingPageUrl(landingPage)) {
+          alert(
+            'The landing page is set to localhost but the emulator appears to be running on a remote host. Please confirm the landing page URL is correct. Visit the Config page to check.'
+          );
         }
 
         const mtoken = $(element).html();


### PR DESCRIPTION
Adds a check on the config page when setting the landing page URL and on index page when posting to the landing page.

Alerts if the landing page is set to localhost (default) but the emulator is running on a remote host.

Fixes #13