### PR TITLE
Fix NPM v9 issue with UIDs and App Service

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.13-alpine3.16
+FROM node:18-alpine3.16
 
 WORKDIR /usr/src/app
 
@@ -13,7 +13,10 @@ ENV PORT=80
 
 RUN apk update && apk upgrade
 
-RUN npm install && ./node_modules/typescript/bin/tsc
+RUN npm install && \
+    find ./node_modules/ ! -user root | xargs chown root:root && \
+    ./node_modules/typescript/bin/tsc
+    
 RUN npx tailwindcss -i ./src/client/input.css -o ./src/client/output.css --minify
 
 EXPOSE 80


### PR DESCRIPTION
This is a "proper" fix for the NPM v9 issue that looks for the problem files and chowns them per: https://azureossd.github.io/2022/06/30/Docker-User-Namespace-remapping-issues/#npm-specific-issues-causing-userns-remap-exceptions

This allows for later versions of NPM to be used. We no longer need to pin the container image Node version.

