### PR TITLE
Fix empty find result causes chown to fail

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,10 +12,13 @@ COPY ./tailwind.config.js ./
 ENV PORT=80
 
 RUN apk update && apk upgrade
+RUN npm install -g npm
 
-RUN npm install && \
-    find ./node_modules/ ! -user root | xargs chown root:root && \
-    ./node_modules/typescript/bin/tsc
+# Docker User Namespace remapping issues in npm 9.x
+# Refer to https://azureossd.github.io/2022/06/30/Docker-User-Namespace-remapping-issues/#npm-specific-issues-causing-userns-remap-exceptions
+# Find any affected files and do a chown to root
+RUN npm install && find ./node_modules/ ! -user root -exec chown root:root {} \;
+RUN ./node_modules/typescript/bin/tsc
     
 RUN npx tailwindcss -i ./src/client/input.css -o ./src/client/output.css --minify
 


### PR DESCRIPTION
In #21, if the result of the find command in the dockerfile was empty, it would cause the chown command to fail. This resulted in a failure of docker build.

Now runs chown on each result - not as performant but should be more robust.