### PR TITLE
Dev container port fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,9 @@
   "name": "Node.js & TypeScript",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
 
-  "initializeCommand": "docker network inspect shared_devcontainer_network > /dev/null || docker network create shared_devcontainer_network --attachable",
+  "initializeCommand": "docker network inspect emulator-net > /dev/null || docker network create emulator-net --attachable",
 
-  "runArgs": ["--network=shared_devcontainer_network", "--hostname=emulator"],
+  "runArgs": ["--network=emulator-net", "--hostname=emulator"],
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   // "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,8 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
+  "appPort": [ "3978:80" ],
+
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "npm install -g npm@9.4.1  && npm install",
 
@@ -25,15 +27,8 @@
         "eslint.validate": ["javascript", "javascriptreact", "typescript"]
       }
     }
-  },
-
-  "portsAttributes": {
-    "3978": {
-      "label": "Application",
-      "onAutoForward": "notify",
-      "requireLocalPort": true
-    }
   }
+
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ const publisherId = process.env.PUBLISHER_ID;
 const publisherTenantId = process.env.PUBLISHER_TENANT_ID;
 const publisherAppId = process.env.PUBLISHER_APP_ID;
 const webhookResponse = parseInt(process.env.INTERNAL_WEBHOOK_RESPONSE as string);
-const port = process.env.port ?? process.env.PORT ?? 3978;
+const port = process.env.REMOTE_CONTAINERS === 'true' ? 80 : process.env.port ?? process.env.PORT ?? 3978;
 
 //
 // NB, the publisherId is not currently used. It was implemented to allow the validation of publisherID on activate


### PR DESCRIPTION
To be consistent with running directly in Docker, when running in the Dev Container, this change exposes the application on port 80 locally and port 3978 in the host.

If the emulator is running in the Dev Container:

- If you are connecting from another Docker container or Dev Container instance, make sure it's on the shared network and connect on port 80 using the hostname emulator (ie http://emulator:80).
- If you are connecting from the host, connect using http://localhost:3978.

For details of the shared network, see devcontainer.json runArgs.