### PR TITLE
Update docker networking

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,15 +4,23 @@
   "name": "Node.js & TypeScript",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
 
-  "initializeCommand": "docker network inspect shared_devcontainer_network > /dev/null || docker network create shared_devcontainer_network --attachable",
+  "initializeCommand": "docker network inspect emulator-net > /dev/null || docker network create emulator-net --attachable",
 
-  "runArgs": ["--network=shared_devcontainer_network", "--hostname=emulator"],
+  "runArgs": ["--network=emulator-net", "--hostname=emulator"],
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   // "features": {},
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
+
+  // Expose container port 80 on host port 3978
+  "appPort": ["3978:80"],
+
+  // Set container env variables
+  "containerEnv": {
+    "PORT": "80"
+  },
 
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "npm install -g npm@9.4.1  && npm install",
@@ -25,15 +33,8 @@
         "eslint.validate": ["javascript", "javascriptreact", "typescript"]
       }
     }
-  },
-
-  "portsAttributes": {
-    "3978": {
-      "label": "Application",
-      "onAutoForward": "notify",
-      "requireLocalPort": true
-    }
   }
+
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
 }


### PR DESCRIPTION
To be consistent with running directly in Docker, when running in the Dev Container, this change exposes the application on port 80 locally and port 3978 in the host.

If the emulator is running in the Dev Container:

If you are connecting from another Docker container or Dev Container instance, make sure it's on the shared network and connect on port 80 using the hostname emulator (ie [http://emulator:80](http://emulator/)).
If you are connecting from the host, connect using http://localhost:3978/.
For details of the shared network, see devcontainer.json runArgs.

Replaces #38