### PR TITLE
April feature update

### DIFF
--- a/src/services/default-state-store.ts
+++ b/src/services/default-state-store.ts
@@ -233,7 +233,14 @@ export default class DefaultStateStore implements StateStore {
     return operations !== undefined ? Object.values(operations) : undefined;
   }
 
-  async getPlansForOfferAsync(offerId: string): Promise<Plan[] | undefined> {
-    return this.offers[offerId]?.plans !== undefined ? Object.values(this.offers[offerId].plans) : undefined;
+  async getPlansForOfferAsync(offerId: string, planId?: string): Promise<Plan[] | undefined> {
+
+    const plans = this.offers[offerId]?.plans !== undefined ? Object.values(this.offers[offerId].plans) : undefined;
+
+    if (planId === undefined || plans === undefined) {
+      return plans;
+    }
+
+    return plans.filter(x => x.planId === planId);
   }
 }

--- a/src/subscription-api-impl.ts
+++ b/src/subscription-api-impl.ts
@@ -390,7 +390,7 @@ export const listAvailablePlansApi: ApiCall = async (req, res, services) => {
     return res.send([]);
   }
 
-  const plans = await services.stateStore.getPlansForOfferAsync(subscription.offerId);
+  const plans = await services.stateStore.getPlansForOfferAsync(subscription.offerId, req.query.planId as string | undefined);
 
   return res.send({ plans: plans ?? [] });
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface StateStore {
     subscriptionId: string,
     operationId: string
   ) => Promise<Operation | undefined>;
-  getPlansForOfferAsync: (offerId: string) => Promise<Plan[] | undefined>;
+  getPlansForOfferAsync: (offerId: string, planId?: string) => Promise<Plan[] | undefined>;
 }
 
 export interface Config {

--- a/src/webhook-api-impl.ts
+++ b/src/webhook-api-impl.ts
@@ -152,8 +152,6 @@ const isAckable: (operation: Operation) => boolean = (operation) => {
   switch (operation.action) {
     case 'ChangePlan':
     case 'ChangeQuantity':
-    case 'Reinstate':
-      return true;
   }
 
   return false;


### PR DESCRIPTION
Ignored reinstate webhook response - this now sets the status to "Active" before the webhook is called and ignores the response and patch result even if the result was a 4XX

Added a planId querystring value to listAvailablePlans API call