### PR TITLE
Added internal header to ignore auth for emulator UI

### DIFF
--- a/src/check-token.ts
+++ b/src/check-token.ts
@@ -25,7 +25,7 @@ const getSigningKeyCallback: (jwksUri: string) => GetPublicKeyOrSecret = (jwksUr
 
 export const checkToken = (services: ServicesContainer) => (req: Request, res: Response, next: NextFunction) => {
 
-  if (services.config.requireAuth !== true) {
+  if (services.config.requireAuth !== true || req.headers['x-ignore-auth'] !== undefined) {
     next();
     return;
   }

--- a/src/client/core.js
+++ b/src/client/core.js
@@ -6,7 +6,8 @@ async function callAPI(path, method, body) {
         method,
         body: body ? JSON.stringify(body) : undefined,
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'x-ignore-auth': 'true'
         }
     });
 
@@ -166,7 +167,8 @@ async function doFetch(name, url, body, method, headers) {
         headers: {
             ...headers,
             ...contentTypeHeader,
-            "x-ms-requestid": id
+            "x-ms-requestid": id,
+            "x-ignore-auth": "true"
         },
         body
     });

--- a/src/client/subscriptions.js
+++ b/src/client/subscriptions.js
@@ -1,5 +1,4 @@
 /// <reference path="core.js" />
-/// <reference path="notifications.js" />
 
 let offers;
 


### PR DESCRIPTION
On the subscriptions page, when requesting the available plans _and_ having Require Auth set to true, the request was failing because the UI doesn't know how to get a valid token. Added in a x- header to override the auth check on the service